### PR TITLE
trim trailing space from scanner input

### DIFF
--- a/src/android/com/datasplice/cordova/plugin/koamtac/KoamTacScanner.java
+++ b/src/android/com/datasplice/cordova/plugin/koamtac/KoamTacScanner.java
@@ -205,8 +205,9 @@ public class KoamTacScanner extends CordovaPlugin {
      * @param scannerMessage
      */
     private void sendPluginResult(final PluginResult.Status status, final String scannerMessage, final boolean keepCallback) {
-        Log.d(TAG, "sendPluginResult(\"" + scannerMessage + "\")");
-        PluginResult pluginResult = new PluginResult(status, scannerMessage);
+        String trimmedScannerMessage = new String(scannerMessage).trim();
+        Log.d(TAG, "sendPluginResult(\"" + trimmedScannerMessage + "\")");
+        PluginResult pluginResult = new PluginResult(status, trimmedScannerMessage);
         pluginResult.setKeepCallback(keepCallback);
         callbackContext.sendPluginResult(pluginResult);
     }


### PR DESCRIPTION
The DataSplice client should probably trim invisible characters from all scanner input as a separate issue. However the scanner should not be sending trailing invisibles in the first place.